### PR TITLE
Club100 addjson

### DIFF
--- a/list.json
+++ b/list.json
@@ -34,5 +34,10 @@
       "name": "Aleksandr Shepelev",
       "description": "xRocket",
       "walletAddress": "UQCYgggSxp2e0-VpAWllGqr97tVkCvSivF16hOfrawgfV1OK"
+    },
+    {
+      "name": "w0rm bLue",
+      "description": "the club 100",
+      "walletAddress": "UQD3L3R9zVwobj7b3gdieI5_JgYgXQ_kMwRRCHSxjLIbH47c"
     }
   ] 


### PR DESCRIPTION
Кошелек создателя Club 100. Было много сливов этого кошелька. Принадлежность к автору также можно объяснить, благодаря именным NFT. На его основной кошелек также ведет твинк, который использовался для приватного чата Ворма, пруфы ниже.

https://tonviewer.com/transaction/d68ff51af2616dbf3ee80b6085780aa14303a6ff169b40709df434486f1bfa69?utm_source=tonkeeper Моя транза на его второй кошелек для приватки.

Визуализация переведенных средств на основу:
![Screenshot_1](https://github.com/user-attachments/assets/f5e7a0fe-4fd0-4201-bd92-0f6373235125)

Также очевидные намеки: 
![Screenshot_2](https://github.com/user-attachments/assets/d0400c8f-88f4-4721-bc88-faad0c71c8fd)

Мой юзернейм - @tuptuppp
Мой кошелек - UQAbrZ8C6qUAgwfjZXLw54CabmmlL9Rnfem90yOPJ-fYBXbM
